### PR TITLE
[SERVER-172] Implement support for Aisling time

### DIFF
--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.cs
@@ -55,6 +55,9 @@ namespace Hybrasyl.XSD
         [System.Xml.Serialization.XmlArrayItemAttribute("board", IsNullable = false, ElementName = "board")]
         public List<GlobalBoard> Boards { get; set; }
 
+        [XmlElementAttribute("timeconfig")]
+        public TimeConfig Time { get; set; } 
+
         public HybrasylConfig()
         {
             this.Boards = new List<GlobalBoard>();
@@ -62,6 +65,7 @@ namespace Hybrasyl.XSD
             this.Network = new Network();
             this.Datastore = new DataStore();
             this.Logging = new LogConfig();
+            this.Time = new TimeConfig();
         }
     }
 
@@ -120,6 +124,94 @@ namespace Hybrasyl.XSD
         /// <remarks/>
         off = Int32.MaxValue,
     }
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1038.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Config")]
+    [System.Xml.Serialization.XmlRootAttribute("time")]
+    public partial class TimeConfig
+    {
+        
+        [XmlElementAttribute("serverstart")]
+        public ServerStart ServerStart { get; set; }
+
+        [XmlArray("ages")]
+        [XmlArrayItemAttribute("age", IsNullable = false, ElementName = "age")]
+        public List<HybrasylAge> Ages { get; set; }
+
+        public TimeConfig()
+        {
+            ServerStart = new ServerStart();
+            Ages = new List<HybrasylAge>();
+
+        }
+
+    }
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1038.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Config")]
+    [System.Xml.Serialization.XmlRootAttribute("serverstart")]
+    public partial class ServerStart
+    {
+        [XmlTextAttribute]
+        private string _serverStart;
+
+        [XmlIgnore]
+        public DateTime ServerStartDate => XmlConvert.ToDateTime(_serverStart,XmlDateTimeSerializationMode.Local);
+
+        [XmlAttributeAttribute("defaultage")]
+        public string DefaultAge;
+
+        [XmlAttributeAttribute("defaultyear")]
+        public string DefaultYear;
+
+        public ServerStart()
+        {
+            DefaultAge = "Hybrasyl";
+            DefaultYear = "1";
+            _serverStart = DateTime.Now.ToString("u");
+
+        }
+    }
+
+
+    [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1038.0")]
+    [System.SerializableAttribute()]
+    [System.Diagnostics.DebuggerStepThroughAttribute()]
+    [System.ComponentModel.DesignerCategoryAttribute("code")]
+    [System.Xml.Serialization.XmlTypeAttribute(Namespace = "http://www.hybrasyl.com/XML/Config")]
+    [System.Xml.Serialization.XmlRootAttribute("HybrasylAge")]
+    public partial class HybrasylAge
+    {
+        [XmlAttributeAttribute(AttributeName = "name")]
+        public string Name { get; set; }
+
+        [XmlAttributeAttribute(AttributeName = "startdate")]
+        public DateTime StartDate { get; set; }
+
+        [XmlIgnore]
+        public DateTime? EndDate { get; set; }
+
+        [XmlAttributeAttribute(AttributeName = "enddate")]
+        public string ValidUntilString
+        {
+            get { return EndDate?.ToString("u"); }
+            set
+            {
+                EndDate = value == null ? (DateTime?)null : DateTime.Parse(value);
+            }
+        }
+
+        [XmlAttributeAttribute(AttributeName = "startyear")]
+        [DefaultValueAttribute(typeof(int), "1")]
+        public int StartYear { get; set; }
+    }
+
 
     [System.CodeDom.Compiler.GeneratedCodeAttribute("System.Xml", "4.6.1038.0")]
     [System.SerializableAttribute()]

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.cs
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.cs
@@ -137,6 +137,9 @@ namespace Hybrasyl.XSD
         [XmlElementAttribute("serverstart")]
         public ServerStart ServerStart { get; set; }
 
+        [XmlIgnore]
+        public DateTime? StartDate => ServerStart.ServerStartDate;
+
         [XmlArray("ages")]
         [XmlArrayItemAttribute("age", IsNullable = false, ElementName = "age")]
         public List<HybrasylAge> Ages { get; set; }
@@ -145,7 +148,6 @@ namespace Hybrasyl.XSD
         {
             ServerStart = new ServerStart();
             Ages = new List<HybrasylAge>();
-
         }
 
     }
@@ -158,25 +160,43 @@ namespace Hybrasyl.XSD
     [System.Xml.Serialization.XmlRootAttribute("serverstart")]
     public partial class ServerStart
     {
-        [XmlTextAttribute]
-        private string _serverStart;
+        [XmlText]      
+        public string Value;
 
         [XmlIgnore]
-        public DateTime ServerStartDate => XmlConvert.ToDateTime(_serverStart,XmlDateTimeSerializationMode.Local);
+        public DateTime? ServerStartDate
+        {
+            get
+            {
+                if (Value != string.Empty)
+                {
+                    try
+                    {
+                        return XmlConvert.ToDateTime(Value, XmlDateTimeSerializationMode.Local);
+                    }
+                    catch (Exception)
+                    {
+                        return null;
+                    }
+                }
+                return null;
+            }
+        }
 
-        [XmlAttributeAttribute("defaultage")]
+        [XmlAttribute("defaultage")]
+        [DefaultValueAttribute(typeof(string), "Hybrasyl")]
         public string DefaultAge;
 
-        [XmlAttributeAttribute("defaultyear")]
-        public string DefaultYear;
+        [XmlAttribute("defaultyear")]
+        [DefaultValueAttribute(typeof(int), "1")]
+        public int DefaultYear;
 
         public ServerStart()
         {
             DefaultAge = "Hybrasyl";
-            DefaultYear = "1";
-            _serverStart = DateTime.Now.ToString("u");
-
+            DefaultYear = 1;          
         }
+
     }
 
 
@@ -198,7 +218,7 @@ namespace Hybrasyl.XSD
         public DateTime? EndDate { get; set; }
 
         [XmlAttributeAttribute(AttributeName = "enddate")]
-        public string ValidUntilString
+        public string EndDateString
         {
             get { return EndDate?.ToString("u"); }
             set
@@ -210,6 +230,13 @@ namespace Hybrasyl.XSD
         [XmlAttributeAttribute(AttributeName = "startyear")]
         [DefaultValueAttribute(typeof(int), "1")]
         public int StartYear { get; set; }
+
+        public bool DateInAge(DateTime datetime)
+        {
+            if (EndDate == null) return datetime.Ticks > StartDate.Ticks;
+            var endDate = (DateTime) EndDate;
+            return datetime.Ticks >= StartDate.Ticks && datetime.Ticks <= endDate.Ticks;
+        } 
     }
 
 

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylConfig.xsd
@@ -88,10 +88,49 @@
   <xs:complexType name="HybrasylConfig">
     <xs:sequence>
       <xs:element name="logging" type="config:LogConfig" minOccurs="0" maxOccurs="1" />
-      <xs:element name="datastore" type="config:DataStore" minOccurs="0" maxOccurs="1" />
-      <xs:element name="network" type="config:Network" minOccurs="0" maxOccurs="1" />
+      <xs:element name="datastore" type="config:DataStore" minOccurs="1" maxOccurs="1" />
+      <xs:element name="network" type="config:Network" minOccurs="1" maxOccurs="1" />
       <xs:element name="access" type="config:Access" minOccurs="0" maxOccurs="1" />
       <xs:element name="boards" type="config:GlobalBoards" minOccurs="0" maxOccurs="1" />
+      <xs:element name="time" type="config:Time" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  <!--
+  <time>
+  <serverstart defaultage="Hybrasyl" defaultyear="1">2016-04-01T01:00:00Z</serverstart>
+  <ages>
+    <age name="Danaan" startdate="2016-04-01" startyear="1"/>
+  </ages>
+</time>
+-->
+  <xs:complexType name="Time">
+    <xs:sequence>
+      <xs:element name="ages" type="config:HybrasylAges" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="ServerStart">
+    <xs:simpleContent>
+      <xs:extension base="xs:dateTime">
+        <xs:attribute name="defaultage" type="hyb:String5" default="Hybrasyl"/>
+        <xs:attribute name="defaultyear" type="xs:int" default="1"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+
+  <xs:complexType name="HybrasylAge">
+    <xs:sequence>
+      <xs:element name="name" type="hyb:String5" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="startdate" type="xs:dateTime" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="enddate" type="xs:dateTime" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="startyear" type="xs:int" minOccurs="0" maxOccurs="1"/>
+    </xs:sequence>
+  </xs:complexType>
+  
+  <xs:complexType name="HybrasylAges">
+    <xs:sequence>
+      <xs:element name="age" minOccurs="1" maxOccurs="unbounded" type="config:HybrasylAge">
+      </xs:element>
     </xs:sequence>
   </xs:complexType>
 

--- a/HybrasylIntegration/HybrasylXML/XSD/hybrasylTypes.xsd
+++ b/HybrasylIntegration/HybrasylXML/XSD/hybrasylTypes.xsd
@@ -12,6 +12,13 @@
 
   <!-- Define common types and elements that we will reuse later -->
 
+  <xs:simpleType name="String5">
+    <xs:restriction base="xs:string">
+      <xs:minLength value="1"/>
+      <xs:maxLength value="32"/>
+    </xs:restriction>
+  </xs:simpleType>
+    
   <xs:simpleType name="String8">
 	  <xs:restriction base="xs:string">
 		  <xs:minLength value="1" />


### PR DESCRIPTION
This PR extends the server configuration XML to support a `<timeconfig>` tag, which can contain the following:

```xml
<timeconfig>
  <serverstart defaultage="Hybrasyl" defaultyear="1">05/30/2016</serverstart>
  <ages>
    <age name="Chadul" startdate="05/30/2016" enddate="09/30/2016" startyear="32">
  </ages>
</timeconfig>
```

Ages are optional. In the absence of any defined ages, the serverstart defaultage/year are used for Aisling time calculations.

There is not currently a lot of error checking so it is possible to have overlapping ages / etc which will give very weird results. For now: don't do this.

